### PR TITLE
seeds with major corrections to the database

### DIFF
--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -2,4 +2,5 @@ class Destination < ApplicationRecord
     has_many :eateries
     has_many :lodgings
     has_many :attractions
+    belongs_to :trip
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,2 +1,4 @@
 class Trip < ApplicationRecord
+    has_many :destinations
+    belongs_to :user
 end

--- a/db/migrate/20200727063230_drop_lodgings.rb
+++ b/db/migrate/20200727063230_drop_lodgings.rb
@@ -1,0 +1,5 @@
+class DropLodgings < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :lodgings
+  end
+end

--- a/db/migrate/20200727063447_create_lodgings.rb
+++ b/db/migrate/20200727063447_create_lodgings.rb
@@ -2,7 +2,7 @@ class CreateLodgings < ActiveRecord::Migration[6.0]
   def change
     create_table :lodgings do |t|
       t.string :name
-      t.integer :destinations_id
+      t.integer :destination_id
 
       t.timestamps
     end

--- a/db/migrate/20200727064007_drop_attractions.rb
+++ b/db/migrate/20200727064007_drop_attractions.rb
@@ -1,0 +1,5 @@
+class DropAttractions < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :attractions
+  end
+end

--- a/db/migrate/20200727064358_create_attractions.rb
+++ b/db/migrate/20200727064358_create_attractions.rb
@@ -3,7 +3,7 @@ class CreateAttractions < ActiveRecord::Migration[6.0]
     create_table :attractions do |t|
       t.string :name
       t.date :date
-      t.integer :destinations_id
+      t.integer :destination_id
 
       t.timestamps
     end

--- a/db/migrate/20200727064727_drop_eatery.rb
+++ b/db/migrate/20200727064727_drop_eatery.rb
@@ -1,0 +1,5 @@
+class DropEatery < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :eateries
+  end
+end

--- a/db/migrate/20200727064909_create_eateries.rb
+++ b/db/migrate/20200727064909_create_eateries.rb
@@ -2,7 +2,7 @@ class CreateEateries < ActiveRecord::Migration[6.0]
   def change
     create_table :eateries do |t|
       t.string :name
-      t.integer :destinations_id
+      t.integer :destination_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_26_073218) do
+ActiveRecord::Schema.define(version: 2020_07_27_064909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_07_26_073218) do
   create_table "attractions", force: :cascade do |t|
     t.string "name"
     t.date "date"
-    t.integer "destinations_id"
+    t.integer "destination_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -35,14 +35,14 @@ ActiveRecord::Schema.define(version: 2020_07_26_073218) do
 
   create_table "eateries", force: :cascade do |t|
     t.string "name"
-    t.integer "destinations_id"
+    t.integer "destination_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "lodgings", force: :cascade do |t|
     t.string "name"
-    t.integer "destinations_id"
+    t.integer "destination_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,131 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.destroy_all
+MealPreference.destroy_all
+Trip.destroy_all
+Destination.destroy_all
+Lodging.destroy_all
+Eatery.destroy_all
+Lodging.destroy_all
+
+user_1 = User.create(
+    first_name: "William",
+    last_name: "Wallace",
+    username: "hammer",
+    city: "Halifax",
+    province: "Nova Scotia",
+    country: "Canada",
+    email: "bill@gmail.com",
+    password: "123456"
+)
+meal_preference_1 = MealPreference.create(
+    gluten_free: false,
+    vegetarian: false,
+    vegan: false,
+    dairy_free: false,
+    low_sodium: false,
+    kosher: false,
+    halal: false,
+    user_id: user_1.id
+)
+
+trip_1 = Trip.create(name: "fishing trip", user_id: user_1.id)
+destination_1 = Destination.create(
+    leaving_from: "Halifax", arriving_to: "Wolfville", start_date: "2020/10/20", end_date: "2020/10/27", trip_id: trip_1.id
+)
+lodging_1 = Lodging.create(name: "Blomidon Inn", destination_id: destination_1.id)
+eatery_1 = Eatery.create(name: "Juniper Food and Wine", destination_id: destination_1.id)
+eatery_2 = Eatery.create(name: "Troy Restaurant", destination_id: destination_1.id)
+attraction_1 = Attraction.create(name: "Harriet Irving Botanical Gardens", date: "2020/10/22", destination_id: destination_1.id)
+attraction_2 = Attraction.create(name: "Lightfood and Wolfville Vineyards", date: "2020/10/24", destination_id: destination_1.id)
+
+destination_2 = Destination.create(
+    leaving_from: "Wolfville", arriving_to: "Digby", start_date: "2020/10/27", end_date: "2020/11/3", trip_id: trip_1.id
+)
+lodging_2 = Lodging.create(name: "Bayside Inn", destination_id: destination_2.id)
+eatery_3 = Eatery.create(name: "The Crow's Nest", destination_id: destination_2.id)
+eatery_4 = Eatery.create(name: "Shoreline Restaurant", destination_id: destination_2.id)
+attraction_3 = Attraction.create(name: "Sandy Cove Beach", date: "2020/10/29", destination_id: destination_2.id)
+attraction_4 = Attraction.create(name: "Prim Point Lighthouse", date: "2020/11/1", destination_id: destination_2.id)
+
+
+trip_2 = Trip.create(name: "hunting trip", user_id: user_1.id)
+destination_3 = Destination.create(
+    leaving_from: "Halifax", arriving_to: "Waverly", start_date: "2020/10/20", end_date: "2020/10/27", trip_id: trip_2.id
+)
+lodging_3 = Lodging.create(name: "Waverly Inn", destination_id: destination_3.id)
+eatery_5 = Eatery.create(name: "The Turtleback Tap and Grill", destination_id: destination_3.id)
+eatery_6 = Eatery.create(name: "Grande Finales Cafe", destination_id: destination_3.id)
+attraction_5 = Attraction.create(name: "Halifax Citadel", date: "2020/10/22", destination_id: destination_3.id)
+attraction_6 = Attraction.create(name: "Shubie Park", date: "2020/10/24", destination_id: destination_3.id)
+
+destination_4 = Destination.create(
+    leaving_from: "Waverly", arriving_to: "Shubenacadie", start_date: "2020/10/27", end_date: "2020/11/3", trip_id: trip_2.id
+)
+lodging_4 = Lodging.create(name: "Snowflake Manor Bed and Breakfast", destination_id: destination_4.id)
+eatery_7 = Eatery.create(name: "Rob Bitar's Ristorante", destination_id: destination_4.id)
+eatery_8 = Eatery.create(name: "The Cup of Soul Cafe", destination_id: destination_4.id)
+attraction_7 = Attraction.create(name: "Shubenacadie Wildlife Park", date: "2020/10/29", destination_id: destination_4.id)
+attraction_8 = Attraction.create(name: "Tidal Bore Rafting Park", date: "2020/11/1", destination_id: destination_4.id)
+
+
+user_2 = User.create(
+    first_name: "John",
+    last_name: "Travolta",
+    username: "joey",
+    city: "Toronto",
+    province: "Ontario",
+    country: "Canada",
+    email: "john@gmail.com",
+    password: "123456"
+)
+meal_preference_2 = MealPreference.create(
+    gluten_free: true,
+    vegetarian: true,
+    vegan: false,
+    dairy_free: false,
+    low_sodium: true,
+    kosher: false,
+    halal: false,
+    user_id: user_2.id
+)
+
+trip_3 = Trip.create(name: "sailing trip", user_id: user_2.id)
+destination_5 = Destination.create(
+    leaving_from: "Toronto", arriving_to: "Vancouver", start_date: "2020/12/15", end_date: "2020/12/22", trip_id: trip_3.id
+)
+lodging_5 = Lodging.create(name: "Fairmont Hotel", destination_id: destination_5.id)
+eatery_9 = Eatery.create(name: "Heirloom Vegetarian Restaurant", destination_id: destination_5.id)
+eatery_10 = Eatery.create(name: "The Acorn Restaurant", destination_id: destination_5.id)
+attraction_9 = Attraction.create(name: "Stanley Park", date: "2020/12/17", destination_id: destination_5.id)
+attraction_10 = Attraction.create(name: "Granville Island", date: "2020/12/20", destination_id: destination_5.id)
+
+destination_6 = Destination.create(
+    leaving_from: "Vancouver", arriving_to: "Victoria", start_date: "2020/12/22", end_date: "2020/12/29", trip_id: trip_3.id
+)
+lodging_6 = Lodging.create(name: "Hotel Fairmont Empress", destination_id: destination_6.id)
+eatery_11 = Eatery.create(name: "Rosalinda Restaurant", destination_id: destination_6.id)
+eatery_12 = Eatery.create(name: "Saveur Restaurant", destination_id: destination_6.id)
+attraction_11 = Attraction.create(name: "Inner Harbour", date: "2020/12/24", destination_id: destination_6.id)
+attraction_12 = Attraction.create(name: "Victoria and Butchart Gardens", date: "2020/1/27", destination_id: destination_6.id)
+
+trip_4 = Trip.create(name: "hiking trip", user_id: user_2.id)
+destination_7 = Destination.create(
+    leaving_from: "Toronto", arriving_to: "Calgary", start_date: "2020/12/15", end_date: "2020/12/22", trip_id: trip_4.id
+)
+lodging_7 = Lodging.create(name: "Hotel Fairmont Palliser", destination_id: destination_7.id)
+eatery_13 = Eatery.create(name: "The Dandelion", destination_id: destination_7.id)
+eatery_14 = Eatery.create(name: "Flores and Pine", destination_id: destination_7.id)
+attraction_13 = Attraction.create(name: "Fish Creek Provincial Park", date: "2020/12/17", destination_id: destination_7.id)
+attraction_14 = Attraction.create(name: "Prince's Island Park", date: "2020/12/20", destination_id: destination_7.id)
+
+destination_8 = Destination.create(
+    leaving_from: "Calgary", arriving_to: "Banff", start_date: "2020/12/22", end_date: "2020/12/29", trip_id: trip_4.id
+)
+lodging_8 = Lodging.create(name: "Fairmont Banff Springs", destination_id: destination_8.id)
+eatery_15 = Eatery.create(name: "Nourish Bistro Banff", destination_id: destination_8.id)
+eatery_16 = Eatery.create(name: "Eden", destination_id: destination_8.id)
+attraction_15 = Attraction.create(name: "Tunnel Mountain Trail", date: "2020/12/24", destination_id: destination_8.id)
+attraction_16 = Attraction.create(name: "Sunshine Meadows", date: "2020/12/ 27", destination_id: destination_8.id)
+

--- a/test/fixtures/attractions.yml
+++ b/test/fixtures/attractions.yml
@@ -2,10 +2,10 @@
 
 one:
   name: MyString
-  date: 2020-07-23
-  destinations_id: 1
+  date: 2020-07-27
+  destination_id: 1
 
 two:
   name: MyString
-  date: 2020-07-23
-  destinations_id: 1
+  date: 2020-07-27
+  destination_id: 1

--- a/test/fixtures/eateries.yml
+++ b/test/fixtures/eateries.yml
@@ -2,8 +2,8 @@
 
 one:
   name: MyString
-  destinations_id: 1
+  destination_id: 1
 
 two:
   name: MyString
-  destinations_id: 1
+  destination_id: 1

--- a/test/fixtures/lodgings.yml
+++ b/test/fixtures/lodgings.yml
@@ -2,8 +2,8 @@
 
 one:
   name: MyString
-  destinations_id: 1
+  destination_id: 1
 
 two:
   name: MyString
-  destinations_id: 1
+  destination_id: 1


### PR DESCRIPTION
The seeds for the Eatery, Attraction, and Lodging tables wouldn't save to the database. The reason is that each of those tables has a 'destinations_id' field, which Rails won't accept.  I had to change it to 'destination_id' (without the 's') in order for the seed to be saved (and all future data as well).  In order to change 'destinations_id' to 'destination_id' I had to create several migrations as follows:
'rails g migration DropLodging' (then put 'drop_table :lodgings' inside the change method of the DropMigration class).
'rake db:migrate'
'rails destroy model Lodging'
'rails g Lodging name:string destination_id:integer'
(repeat for the Eatery and Attraction table)
It took this much effort to remove an 's' from 'destinations_id' in the 'schema.rb' file.